### PR TITLE
Initialize Go CLI for Terraform plan analysis

### DIFF
--- a/cmd/plan-analyzer/main.go
+++ b/cmd/plan-analyzer/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+    "encoding/json"
+    "flag"
+    "fmt"
+    "io/ioutil"
+    "log"
+
+    "github.com/example/plan-analyzer/pkg/parser"
+)
+
+func main() {
+    planPath := flag.String("plan", "", "Path to terraform plan JSON output")
+    flag.Parse()
+
+    if *planPath == "" {
+        log.Fatal("plan path required")
+    }
+
+    data, err := ioutil.ReadFile(*planPath)
+    if err != nil {
+        log.Fatalf("failed to read plan: %v", err)
+    }
+
+    var plan parser.Plan
+    if err := json.Unmarshal(data, &plan); err != nil {
+        log.Fatalf("failed to parse plan: %v", err)
+    }
+
+    summary := parser.Summarize(plan)
+    fmt.Println(summary)
+}
+

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/plan-analyzer
+
+go 1.23.8

--- a/pkg/llm/dummy.go
+++ b/pkg/llm/dummy.go
@@ -1,0 +1,7 @@
+package llm
+
+func Analyze(plan any) (string, error) {
+    // TODO: integrate local model
+    return "LLM analysis not yet implemented", nil
+}
+

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1,0 +1,32 @@
+package parser
+
+import "fmt"
+
+type Plan struct {
+    ResourceChanges []ResourceChange `json:"resource_changes"`
+}
+
+type ResourceChange struct {
+    Type     string `json:"type"`
+    Name     string `json:"name"`
+    Provider string `json:"provider_name"`
+    Change   Change `json:"change"`
+}
+
+type Change struct {
+    Actions []string `json:"actions"`
+}
+
+func Summarize(p Plan) string {
+    summary := make(map[string]int)
+    for _, rc := range p.ResourceChanges {
+        key := fmt.Sprintf("%s.%s", rc.Type, rc.Name)
+        summary[key]++
+    }
+    result := "Summary of changes:\n"
+    for k, v := range summary {
+        result += fmt.Sprintf("%s: %d\n", k, v)
+    }
+    return result
+}
+

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,92 @@
+1. Overall Concept
+Create a service that parses Terraform plans, produces a concise summary of resources and changes, and uses a locally hosted language model (LLM) to analyze that plan. The goal is to flag potential issues or highlight important information, while ensuring all processing stays within the on-prem environment. The service should run as either a standalone executable or containerized application.
+
+Key Requirements
+Local LLM: integrate an on-prem model (e.g., via Hugging Face, Llama-based, or other locally run solution) to avoid sending data offsite.
+
+Testability: architecture needs to support thorough unit tests, integration tests, and logging verification.
+
+Error Handling & Logging: consistent error messaging, structured logs (JSON or similar) with an option for event tracing/auditing.
+
+Deployability: compile to a single executable or container image that customers can run in their environment (Linux-focused).
+
+Offline Operation: make sure any dependencies can be packaged or mirrored locally so that the software functions without an internet connection.
+
+2. Language Choice
+Two good candidates are:
+
+Python:
+
+Extensive ecosystem for natural language processing (Hugging Face, PyTorch, etc.).
+
+Rapid development and easy integration with Terraform plan parsing libraries.
+
+Unit testing via pytest or similar.
+
+Executable packages can be built with tools like PyInstaller or as container images.
+
+Go:
+
+Strong focus on static binaries, simple dependency management, and good performance.
+
+Built-in concurrency features and straightforward error handling.
+
+Good for building single, statically compiled binaries that can run on customer systems.
+
+Both languages can satisfy the requirements, though Python might be easier for LLM integration, while Go offers simpler distribution (static binaries). If you expect heavy use of LLM frameworks that primarily target Python, Python may be simpler.
+
+3. High-Level Architecture
+CLI Service:
+
+Accepts a Terraform plan (either a tfplan file or output from terraform show -json).
+
+Parses the plan to collect a structured representation of changes.
+
+Local LLM Module:
+
+Loads a local model.
+
+Performs analysis on the structured representation to produce a user-readable summary, highlight changes, or detect issues.
+
+Model inference should be containerized or run in a separate process so the main service can recover if the model fails.
+
+Logging & Error Handling:
+
+Central logging module (stdout, files, or a syslog endpoint).
+
+Structured JSON logs that can be consumed by central monitoring.
+
+Error types or error wrapping to make debugging easier.
+
+Testing Framework:
+
+Unit Tests for plan parsing, LLM interface, and logging.
+
+Integration Tests that run the service end-to-end with sample Terraform plans.
+
+Mock LLM module so the tests don’t need a real model for unit tests.
+
+Packaging & Distribution:
+
+Build as a container with all dependencies or compile to a single binary.
+
+Provide installation docs for the customer environment.
+
+4. Roadmap
+Choose the language (Python or Go) and decide whether to embed an existing LLM framework or wrap it in a separate module.
+
+Define the CLI interface and configuration options (plan path, model location, logging settings, output format).
+
+Create the Terraform plan parser and produce an internal representation (JSON, data structures).
+
+Integrate the LLM module: feed the plan representation, receive structured responses.
+
+Implement error handling and logging from the outset—include log levels, error codes, and consistent formats.
+
+Write a full suite of tests (unit and integration).
+
+Build packaging scripts to produce a final executable or container image.
+
+Document usage, licensing, and support.
+
+This approach should allow the service to run completely offline in a customer’s environment while maintaining strong testability, error handling, and clear logging.

--- a/status.md
+++ b/status.md
@@ -1,0 +1,17 @@
+# Status
+
+## Backlog
+- Parse Terraform plan JSON
+- Integrate local LLM interface
+- Add logging and error handling
+- Write unit and integration tests
+- Packaging as container or binary
+- Documentation
+
+## In Progress
+- Implement CLI skeleton
+
+## Done
+- Set up Go module and project structure
+- Create initial project files and planning documents
+


### PR DESCRIPTION
## Summary
- add planning doc describing concept for offline Terraform plan analysis with LLM
- track progress in `status.md`
- initialize Go module and stub CLI application
- add basic parser and dummy LLM interface

## Testing
- `go build ./cmd/plan-analyzer`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6840a154d1bc832895ac3baf458eaf68